### PR TITLE
Fix golang version in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.13.15'
+          go-version: '1.21'
       - name: Install make
         run: sudo apt-get update && sudo apt-get install make -y
       - name: Build Binaries


### PR DESCRIPTION
Fixes the following GitHub Actions issue

https://github.com/reverbdotcom/protopkg/actions/runs/6264688003/job/17011921850

```
build github.com/reverbdotcom/protopkg: cannot load io/fs: malformed module path "io/fs": missing dot in first path element
make: *** [Makefile:15: bin/protopkg.linux] Error 1
Error: Process completed with exit code 2.
```